### PR TITLE
[Documentation] CFF:  Cite Rust Crate `clap`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -68,5 +68,3 @@ references:
     repository-code: https://github.com/sorairolake/sysexits-rs
     title: sysexits-rs
     url: https://docs.rs/sysexits
-
-################################################################################

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -68,3 +68,19 @@ references:
     repository-code: https://github.com/sorairolake/sysexits-rs
     title: sysexits-rs
     url: https://docs.rs/sysexits
+  - type: software
+    date-released: 2023-02-28
+    version: 4.1.8
+    abstract: A full featured, fast Command Line Argument Parser for Rust
+    authors:
+      - alias: kbknapp
+        family-names: Knapp
+        given-names: Kevin B.
+      - name: The Clap Community
+    license:
+      - Apache-2.0
+      - MIT
+    repository-artifact: https://crates.io/crates/clap
+    repository-code: https://github.com/clap-rs/clap
+    title: clap
+    url: https://docs.rs/clap

--- a/changelog.d/20230310_132139_41898282+github-actions[bot]_clap_cff.rst
+++ b/changelog.d/20230310_132139_41898282+github-actions[bot]_clap_cff.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. .....
+..
+.. - A bullet item for the Fixed category.
+..
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/changelog.d/20230310_132139_41898282+github-actions[bot]_clap_cff.rst
+++ b/changelog.d/20230310_132139_41898282+github-actions[bot]_clap_cff.rst
@@ -2,11 +2,11 @@
 ..
 .. Uncomment the header that is right (remove the leading dots).
 ..
-.. Added
-.. .....
-..
-.. - A bullet item for the Added category.
-..
+Added
+.....
+
+- CFF:  cite Rust crate ``clap``
+
 .. Changed
 .. .......
 ..


### PR DESCRIPTION
Clap is now CFF-citable due to https://github.com/clap-rs/clap/pull/4752.