### PR TITLE
[Documentation] CFF:  Cite Rust Crate `chrono`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -88,3 +88,27 @@ references:
     repository-code: https://github.com/clap-rs/clap
     title: clap
     url: https://docs.rs/clap
+  - type: software
+    date-released: 2023-03-12
+    version: 0.4.24
+    abstract: Date and time library for Rust
+    authors:
+      - alias: quodlibetor
+        family-names: Maister
+        given-names: Brandon W.
+      - alias: djc
+        family-names: Ochtman
+        given-names: Dirkjan
+      - alias: lifthrasiir
+        family-names: Seonghoon
+        given-names: Kang
+      - alias: esheppa
+        family-names: Sheppard
+        given-names: Eric
+    license:
+      - Apache-2.0
+      - MIT
+    repository-artifact: https://crates.io/crates/chrono
+    repository-code: https://github.com/chronotope/chrono
+    title: chrono
+    url: https://docs.rs/chrono

--- a/changelog.d/20230314_181749_41898282+github-actions[bot]_chrono_cff.rst
+++ b/changelog.d/20230314_181749_41898282+github-actions[bot]_chrono_cff.rst
@@ -2,11 +2,11 @@
 ..
 .. Uncomment the header that is right (remove the leading dots).
 ..
-.. Added
-.. .....
-..
-.. - A bullet item for the Added category.
-..
+Added
+.....
+
+- CFF:  cite Rust crate ``chrono``
+
 .. Changed
 .. .......
 ..

--- a/changelog.d/20230314_181749_41898282+github-actions[bot]_chrono_cff.rst
+++ b/changelog.d/20230314_181749_41898282+github-actions[bot]_chrono_cff.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. .....
+..
+.. - A bullet item for the Fixed category.
+..
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..


### PR DESCRIPTION
`chrono` is now CFF-citable due to https://github.com/chronotope/chrono/pull/982.