### PR TITLE
[Documentation] Cite sysexits in CFF, again

### DIFF
--- a/.github/workflows/cff.yml
+++ b/.github/workflows/cff.yml
@@ -76,6 +76,11 @@ jobs:
           branch: main
           repository: kevinmatthes/aeruginous-io
 
+      - uses: ./curl-cffref
+        with:
+          branch: main
+          repository: sorairolake/sysexits-rs
+
       - uses: peter-evans/create-pull-request@v7.0.5
         with:
           assignees: |

--- a/changelog.d/20241101_182034_github-actions[bot]_cite-sysexits-rs-again.ron
+++ b/changelog.d/20241101_182034_github-actions[bot]_cite-sysexits-rs-again.ron
@@ -1,0 +1,8 @@
+(
+  references: {},
+  changes: {
+    "Added": [
+      "CFF:  sorairolake/sysexits-rs",
+    ],
+  },
+)


### PR DESCRIPTION
This PR adds ``sysexits-rs`` again to the CFF.