### PR TITLE
[Bugfix] CI:  JSON formatting workflow writes formatted code back to original source file

### DIFF
--- a/.github/workflows/format-json-files.yml
+++ b/.github/workflows/format-json-files.yml
@@ -37,7 +37,8 @@ jobs:
 
       - run: |
           # Find all JSON files and format them in-place
-          find . -type f -name "*.json" -exec jq . -S {} \;
+          find . -type f -name "*.json" -exec sh -c \
+            'jq . -S "$1" > tmp.json && mv tmp.json "$1"' _ {} \;
 
           # Check if there are any changes after formatting
           if ! git diff --exit-code; then

--- a/changelog.d/20241110_131435_github-actions[bot]_json-formatting-workflow.ron
+++ b/changelog.d/20241110_131435_github-actions[bot]_json-formatting-workflow.ron
@@ -1,0 +1,8 @@
+(
+  references: {},
+  changes: {
+    "Fixed": [
+      "CI:  JSON formatting workflow now writes formatted code back to original file",
+    ],
+  },
+)


### PR DESCRIPTION
This PR fixes a bug in the JSON formatting workflow.  The formatted JSON code is now written back to the original source file.