### PR TITLE
[Bugfix] CI:  JSON formatting workflow does not need to install jq

### DIFF
--- a/.github/workflows/format-json-files.yml
+++ b/.github/workflows/format-json-files.yml
@@ -27,6 +27,9 @@ on:
       - '**/*.json'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   format-json:
     runs-on: ubuntu-latest

--- a/.github/workflows/format-json-files.yml
+++ b/.github/workflows/format-json-files.yml
@@ -32,8 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ github.head_ref }}
+
       - uses: fregante/setup-git-user@v2.0.2
-      - run: sudo apt-get update && sudo apt-get install -y jq
 
       - run: |
           # Find all JSON files and format them in-place

--- a/changelog.d/20241110_133829_github-actions[bot]_json-formatting-workflow-2.ron
+++ b/changelog.d/20241110_133829_github-actions[bot]_json-formatting-workflow-2.ron
@@ -1,0 +1,8 @@
+(
+  references: {},
+  changes: {
+    "Fixed": [
+      "CI:  JSON formatting workflow does not need to install formatter jq",
+    ],
+  },
+)


### PR DESCRIPTION
This PR fixes several bugs in the JSON formatting workflow.  For example, the formatter jq does not need to be installed on the runner as it is already installed out-of-the-box.  Furthermore, the permission to change contents was granted and the branch to be checked out was set to the current HEAD.